### PR TITLE
Skip Bluesky post for older articles & add categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ Markdown processing is extended with two plugins in `src/plugins/remark/`:
 
 Both are registered in `astro.config.mjs`, alongside `remark-math` + KaTeX for math and Shiki meta-highlighting for code.
 
+## Deployment
+
+Pushing to `main` triggers `.github/workflows/deploy.yml`, which builds the site with `withastro/action` and publishes it to GitHub Pages.
+
+## Bluesky automation
+
+Once a deploy succeeds, `.github/workflows/bluesky-post.yml` runs `scripts/post-new-articles-to-bluesky.mjs`, which announces any article that doesn't yet have a matching post on the account's Bluesky feed — no local state is tracked; it just checks which article URLs are missing from the account's own recent posts. Each announcement is a link card (thumbnail + title + description pulled from frontmatter), built via `@atproto/api`.
+
+- **`bluesky.config.json`** (repo root) sets the defaults: `defaultPostText` (the caption used when an article doesn't override it) and `hashtagsEnabled` (whether `categories` are turned into hashtags).
+- **Per-article frontmatter overrides**, all optional:
+  - `blueskyText` — custom caption for that article's post (an empty string posts the card with no caption at all).
+  - `blueskyHashtags` — `true`/`false` to override the global `hashtagsEnabled` setting for just that article.
+  - `categories` (required on every article) are converted to `#PascalCase` hashtags, e.g. `Computer Science` → `#ComputerScience`, and appended after the caption when hashtags are enabled.
+- **Secrets**: the workflow needs `BLUESKY_IDENTIFIER` and `BLUESKY_APP_PASSWORD` (an [app password](https://bsky.app/settings/app-passwords), not the account password) set as repository secrets.
+- **Local testing**: `BLUESKY_IDENTIFIER=... BLUESKY_APP_PASSWORD=... npm run bluesky:post -- --dry-run` logs what would be posted without actually posting. It can also be run on demand from the Actions tab (`workflow_dispatch`) instead of waiting for a deploy.
+
 ## Development
 
 ```sh
@@ -50,6 +66,12 @@ src/
 ├── pages/               # routes
 ├── plugins/remark/      # custom remark plugins
 └── styles/              # global styles (Tailwind)
+scripts/
+└── post-new-articles-to-bluesky.mjs  # Bluesky auto-post script
+.github/workflows/
+├── deploy.yml           # build + deploy to GitHub Pages
+└── bluesky-post.yml     # announce new articles on Bluesky after a deploy
+bluesky.config.json      # Bluesky default post text + hashtag toggle
 .claude/
 ├── agents/              # blog-interactive-component-builder subagent
 ├── skills/              # wire-interactive-components skill

--- a/bluesky.config.json
+++ b/bluesky.config.json
@@ -1,3 +1,4 @@
 {
-  "defaultPostText": "🔔 New Post"
+  "defaultPostText": "🔔 New Post",
+  "hashtagsEnabled": true
 }

--- a/scripts/post-new-articles-to-bluesky.mjs
+++ b/scripts/post-new-articles-to-bluesky.mjs
@@ -38,6 +38,8 @@ function readArticles() {
         bannerAbsPath: path.resolve(ARTICLES_DIR, data.banner),
         url: `${SITE_URL}/blog/${slug}/`,
         text: data.blueskyText ?? config.defaultPostText,
+        categories: data.categories,
+        hashtagsOverride: data.blueskyHashtags,
       }
     })
 }
@@ -63,13 +65,25 @@ async function fetchAlreadyPostedUrls(agent) {
   return posted
 }
 
+function categoriesToHashtags(categories) {
+  return categories.map((c) => `#${c.replace(/\s+/g, '')}`).join(' ')
+}
+
+function buildFinalText(article) {
+  const hashtagsEnabled = article.hashtagsOverride ?? config.hashtagsEnabled
+  const hashtags = hashtagsEnabled
+    ? categoriesToHashtags(article.categories)
+    : ''
+  return [article.text, hashtags].filter(Boolean).join('\n\n')
+}
+
 async function postArticle(agent, article) {
   const bannerBytes = readFileSync(article.bannerAbsPath)
   const { data: blob } = await agent.uploadBlob(bannerBytes, {
     encoding: 'image/png',
   })
 
-  const rt = new RichText({ text: article.text })
+  const rt = new RichText({ text: buildFinalText(article) })
   await rt.detectFacets(agent)
 
   await agent.post({
@@ -112,7 +126,7 @@ async function main() {
     if (isDryRun) {
       console.log(
         `[dry-run] Would post "${article.slug}" as a link card:\n` +
-          `  text: ${article.text}\n` +
+          `  text: ${buildFinalText(article)}\n` +
           `  title: ${article.title}\n` +
           `  description: ${article.description}\n` +
           `  uri: ${article.url}\n` +

--- a/scripts/post-new-articles-to-bluesky.mjs
+++ b/scripts/post-new-articles-to-bluesky.mjs
@@ -2,7 +2,9 @@
 // Announces newly published articles on Bluesky with a link-card (thumbnail
 // + title + description). "New" is determined by checking which article
 // URLs don't already have a matching post in the account's own feed, so no
-// state needs to be tracked in the repo.
+// state needs to be tracked in the repo. Only articles published within the
+// last RECENT_DAYS are considered, so once the feed lookup can no longer
+// reach far enough back the back catalogue still can't be reposted.
 import { readFileSync, readdirSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -16,6 +18,10 @@ const REPO_ROOT = path.resolve(
 const ARTICLES_DIR = path.join(REPO_ROOT, 'src/articles')
 const SITE_URL = 'https://filipmelka.com'
 const MAX_FEED_PAGES = 20
+// The feed lookup only reaches back MAX_FEED_PAGES * 100 posts. Articles
+// older than this are never candidates, so they can't be reposted once they
+// fall outside that window.
+const RECENT_DAYS = 30
 
 const config = JSON.parse(
   readFileSync(path.join(REPO_ROOT, 'bluesky.config.json'), 'utf8'),
@@ -111,10 +117,26 @@ async function main() {
     password: process.env.BLUESKY_APP_PASSWORD,
   })
 
+  const cutoff = Date.now() - RECENT_DAYS * 24 * 60 * 60 * 1000
+
   const alreadyPosted = await fetchAlreadyPostedUrls(agent)
-  const candidates = articles
-    .filter((article) => !alreadyPosted.has(article.url))
+  const unposted = articles.filter((article) => !alreadyPosted.has(article.url))
+  const candidates = unposted
+    .filter((article) => article.pubDate.getTime() > cutoff)
     .sort((a, b) => a.pubDate - b.pubDate)
+
+  // An article with no post and a pubDate older than the window is almost
+  // always a pubDate that wasn't bumped to the publish date. Say so instead
+  // of silently reporting nothing to do.
+  for (const article of unposted) {
+    if (article.pubDate.getTime() <= cutoff) {
+      console.warn(
+        `Skipping "${article.slug}": never posted, but its pubDate ` +
+          `(${article.pubDate.toISOString().slice(0, 10)}) is older than ` +
+          `${RECENT_DAYS} days. Bump pubDate if it should be announced.`,
+      )
+    }
+  }
 
   if (candidates.length === 0) {
     console.log('No new articles to post.')

--- a/src/articles/i-created-a-claude-skill-for-usage-aware-automation.mdx
+++ b/src/articles/i-created-a-claude-skill-for-usage-aware-automation.mdx
@@ -1,7 +1,7 @@
 ---
 title: I Created a Claude Skill for Usage-Aware Automation
 description: I built Claude Gauge, a skill that gives Claude Code visibility into your usage limits, so you can automate work around whatever capacity would otherwise go to waste.
-pubDate: 2025-07-30
+pubDate: 2026-07-30
 banner: './banners/i-created-a-claude-skill-for-usage-aware-automation.png'
 blueskyText: '🔔 New Post #claude #claude-code'
 categories: ['Claude', 'Automation']

--- a/src/articles/i-created-a-claude-skill-for-usage-aware-automation.mdx
+++ b/src/articles/i-created-a-claude-skill-for-usage-aware-automation.mdx
@@ -4,6 +4,7 @@ description: I built Claude Gauge, a skill that gives Claude Code visibility int
 pubDate: 2025-07-30
 banner: './banners/i-created-a-claude-skill-for-usage-aware-automation.png'
 blueskyText: '🔔 New Post #claude #claude-code'
+categories: ['Claude', 'Automation']
 ---
 
 I built and published my first Claude skill: [Claude Gauge](https://github.com/filip-melka/claude-gauge).

--- a/src/articles/is-1-larger-than-0999.mdx
+++ b/src/articles/is-1-larger-than-0999.mdx
@@ -3,6 +3,7 @@ title: Is 1 Larger Than 0.999...?
 description: I used to think 0.999... was just a hair short of 1 - turns out I was wrong. Let's see all the different ways to prove they're actually the exact same number, and then use the same idea to solve Zeno's paradox.
 pubDate: 2025-07-19
 banner: './banners/is-1-larger-than-0999.png'
+categories: ['Mathematics']
 ---
 
 import { ComparisonReveal } from './components/comparison-reveal'

--- a/src/articles/is-1-larger-than-0999.mdx
+++ b/src/articles/is-1-larger-than-0999.mdx
@@ -1,7 +1,7 @@
 ---
 title: Is 1 Larger Than 0.999...?
 description: I used to think 0.999... was just a hair short of 1 - turns out I was wrong. Let's see all the different ways to prove they're actually the exact same number, and then use the same idea to solve Zeno's paradox.
-pubDate: 2025-07-19
+pubDate: 2026-07-19
 banner: './banners/is-1-larger-than-0999.png'
 categories: ['Mathematics']
 ---

--- a/src/articles/start-building-tuis-with-bubble-tea.mdx
+++ b/src/articles/start-building-tuis-with-bubble-tea.mdx
@@ -1,7 +1,7 @@
 ---
 title: Start Building TUIs with Bubble Tea
 description: A beginner-friendly walkthrough of Bubble Tea, the Go framework for building terminal apps - covering the Elm Architecture, commands, alt screen, logging, and the wider ecosystem.
-pubDate: 2025-07-24
+pubDate: 2026-07-24
 banner: './banners/start-building-tuis-with-bubble-tea.png'
 blueskyText: ''
 categories: ['Go', 'TUI']

--- a/src/articles/start-building-tuis-with-bubble-tea.mdx
+++ b/src/articles/start-building-tuis-with-bubble-tea.mdx
@@ -4,6 +4,7 @@ description: A beginner-friendly walkthrough of Bubble Tea, the Go framework for
 pubDate: 2025-07-24
 banner: './banners/start-building-tuis-with-bubble-tea.png'
 blueskyText: ''
+categories: ['Go', 'TUI']
 ---
 
 import { ElmArchitectureExplainer } from './components/elm-architecture-explainer'

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -10,7 +10,9 @@ const articles = defineCollection({
       description: z.string(),
       pubDate: z.coerce.date(),
       banner: image(),
+      categories: z.array(z.string()),
       blueskyText: z.string().optional(),
+      blueskyHashtags: z.boolean().optional(),
     }),
 })
 


### PR DESCRIPTION
- Add `categories` frontmatter - turn into Bluesky hashtags
- Correct publish dates
- Skip Bluesky post for articles older than 30 days